### PR TITLE
Fixed update hook to send an id to the afterUpdate hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,97 +1,98 @@
 {
-  "name": "@spacelabstech/firestoreorm",
-  "version": "1.1.0",
-  "description": "Type-safe Firestore ORM with validation, soft deletes, lifecycle hooks, and powerful query builder. Built for Firebase Admin SDK with full TypeScript support.",
-  "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
-    }
-  },
-  "files": [
-    "dist/**/*",
-    "README.md",
-    "LICENSE"
-  ],
-  "scripts": {
-    "clean": "rimraf dist .tsbuildinfo coverage",
-    "build": "rm -rf dist && tsc",
-    "prepublishOnly": "npm run build",
-    "test": "jest",
-    "test:dotnotation": "jest src/tests/dotNotation.test.ts",
-    "test:watch": "jest --watch",
-    "test:performance": "ts-node-dev --respawn --transpile-only ./src/benchmarks/performance.test.ts"
-  },
-  "keywords": [
-    "firestore",
-    "orm",
-    "firebase",
-    "firebase-admin",
-    "typescript",
-    "type-safe",
-    "database",
-    "nosql",
-    "cloud-firestore",
-    "google-cloud",
-    "repository-pattern",
-    "soft-delete",
-    "validation",
-    "zod",
-    "query-builder",
-    "transaction",
-    "batch-operations",
-    "pagination",
-    "hooks",
-    "lifecycle",
-    "data-layer",
-    "backend",
-    "node",
-    "server-side",
-    "firebase-orm",
-    "firestore-wrapper",
-    "firestore-repository",
-    "fireorm-altenative",
-    "typesaurus-altenative",
-    "typeorm-alternative",
-    "prisma-alternative"
-  ],
-  "author": {
-    "name": "HBFL3Xx @Spacelabs",
-    "email": "hbfl3x@gmail.com",
-    "url": "https://github.com/HBFLEX"
-  },
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/HBFLEX/spacelabs-firestoreorm"
-  },
-  "bugs": {
-    "url": "https://github.com/HBFLEX/spacelabs-firestoreorm/issues"
-  },
-  "homepage": "https://github.com/HBFLEX/spacelabs-firestoreorm#readme",
-  "engines": {
-    "node": ">=16.0.0"
-  },
-  "peerDependencies": {
-    "firebase-admin": "^12.0.0 || ^13.0.0",
-    "zod": "^3.0.0 || ^4.0.0"
-  },
-  "dependencies": {
-    "firebase-admin": "^12.0.0 || ^13.0.0",
-    "zod": "^3.0.0 || ^4.0.0"
-  },
-  "devDependencies": {
-    "@types/jest": "^30.0.0",
-    "jest": "^30.2.0",
-    "ts-jest": "^29.4.5",
-    "ts-node": "^10.9.2",
-    "ts-node-dev": "^2.0.0",
-    "typescript": "^5.9.3"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+	"name": "@spacelabstech/firestoreorm",
+	"version": "1.1.0",
+	"description": "Type-safe Firestore ORM with validation, soft deletes, lifecycle hooks, and powerful query builder. Built for Firebase Admin SDK with full TypeScript support.",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"import": "./dist/index.js",
+			"types": "./dist/index.d.ts"
+		}
+	},
+	"files": [
+		"dist/**/*",
+		"README.md",
+		"LICENSE"
+	],
+	"scripts": {
+		"clean": "rimraf dist .tsbuildinfo coverage",
+		"build": "rm -rf dist && tsc",
+		"prepublishOnly": "npm run build",
+		"test": "jest",
+		"test:afterupdatehook": "jest src/tests/afterUpdateHook.test.ts",
+		"test:dotnotation": "jest src/tests/dotNotation.test.ts",
+		"test:watch": "jest --watch",
+		"test:performance": "ts-node-dev --respawn --transpile-only ./src/benchmarks/performance.test.ts"
+	},
+	"keywords": [
+		"firestore",
+		"orm",
+		"firebase",
+		"firebase-admin",
+		"typescript",
+		"type-safe",
+		"database",
+		"nosql",
+		"cloud-firestore",
+		"google-cloud",
+		"repository-pattern",
+		"soft-delete",
+		"validation",
+		"zod",
+		"query-builder",
+		"transaction",
+		"batch-operations",
+		"pagination",
+		"hooks",
+		"lifecycle",
+		"data-layer",
+		"backend",
+		"node",
+		"server-side",
+		"firebase-orm",
+		"firestore-wrapper",
+		"firestore-repository",
+		"fireorm-altenative",
+		"typesaurus-altenative",
+		"typeorm-alternative",
+		"prisma-alternative"
+	],
+	"author": {
+		"name": "HBFL3Xx @Spacelabs",
+		"email": "hbfl3x@gmail.com",
+		"url": "https://github.com/HBFLEX"
+	},
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/HBFLEX/spacelabs-firestoreorm"
+	},
+	"bugs": {
+		"url": "https://github.com/HBFLEX/spacelabs-firestoreorm/issues"
+	},
+	"homepage": "https://github.com/HBFLEX/spacelabs-firestoreorm#readme",
+	"engines": {
+		"node": ">=16.0.0"
+	},
+	"peerDependencies": {
+		"firebase-admin": "^12.0.0 || ^13.0.0",
+		"zod": "^3.0.0 || ^4.0.0"
+	},
+	"dependencies": {
+		"firebase-admin": "^12.0.0 || ^13.0.0",
+		"zod": "^3.0.0 || ^4.0.0"
+	},
+	"devDependencies": {
+		"@types/jest": "^30.0.0",
+		"jest": "^30.2.0",
+		"ts-jest": "^29.4.5",
+		"ts-node": "^10.9.2",
+		"ts-node-dev": "^2.0.0",
+		"typescript": "^5.9.3"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/src/core/FirestoreRepository.ts
+++ b/src/core/FirestoreRepository.ts
@@ -466,8 +466,10 @@ export class FirestoreRepository<T extends { id?: ID }> {
 
             await docRef.set(updated, { merge: true });
 
-            await this.runHooks('afterUpdate', updated);
-            return updated as T & {id: ID};
+            const updatedWithId = { ...updated, id };
+            await this.runHooks('afterUpdate', updatedWithId);
+
+            return updatedWithId as T & { id: ID };
         }catch(error: any){
             if(error instanceof z.ZodError){
                 throw new ValidationError(error.issues);

--- a/src/tests/afterUpdateHook.test.ts
+++ b/src/tests/afterUpdateHook.test.ts
@@ -1,0 +1,63 @@
+import { FirestoreRepository } from "../core/FirestoreRepository.js";
+
+// mock Firestore classes and methods
+const mockSet = jest.fn();
+const mockGet = jest.fn();
+const mockDoc = jest.fn(() => ({
+	get: mockGet,
+	set: mockSet,
+}));
+const mockCollection = jest.fn(() => ({
+	doc: mockDoc,
+}));
+
+jest.mock("firebase-admin/firestore", () => ({
+	Firestore: jest.fn().mockImplementation(() => ({
+		collection: mockCollection,
+	})),
+}));
+
+describe("FirestoreRepository update() id behavior (mocked Firestore)", () => {
+	let userRepo: FirestoreRepository<{ id?: string; name: string }>;
+
+	beforeEach(() => {
+		const db = new (require("firebase-admin/firestore").Firestore)();
+		userRepo = new FirestoreRepository<{ id?: string; name: string }>(db, "test_users_id_behavior");
+	});
+
+	it("should return updated document including id", async () => {
+		const fakeId = "user123";
+		const fakeData = { name: "Original Name" };
+
+		// mock Firestore get() to return existing data
+		mockGet.mockResolvedValueOnce({
+			exists: true,
+			data: () => fakeData,
+		});
+
+		mockSet.mockResolvedValueOnce(undefined);
+
+		const updated = await userRepo.update(fakeId, { name: "Updated Name" });
+
+		expect(updated.id).toBe(fakeId);
+		expect(updated.name).toBe("Updated Name");
+	});
+
+	it("should pass id to afterUpdate hook", async () => {
+		const hookSpy = jest.fn();
+		(userRepo as any).hooks = { afterUpdate: [hookSpy] };
+
+		const fakeId = "user456";
+		const fakeData = { name: "Original" };
+
+		mockGet.mockResolvedValueOnce({ exists: true, data: () => fakeData });
+		mockSet.mockResolvedValueOnce(undefined);
+
+		await userRepo.update(fakeId, { name: "Hook Updated" });
+
+		expect(hookSpy).toHaveBeenCalledTimes(1);
+		const hookPayload = hookSpy.mock.calls[0][0];
+		expect(hookPayload.id).toBe(fakeId);
+		expect(hookPayload.name).toBe("Hook Updated");
+	});
+});


### PR DESCRIPTION
This pr fixes the issue https://github.com/HBFLEX/spacelabs-firestoreorm/issues/4#issue-3967881689